### PR TITLE
feat: Add config to support Pickle serializer customization

### DIFF
--- a/transmissions/models.py
+++ b/transmissions/models.py
@@ -12,13 +12,17 @@
     Most commonly email or mobile push for iOS or Android.
 """
 
-# import pickle
 from base64 import b64decode, b64encode
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
-from django.core.urlresolvers import reverse
+
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
+
 from django.db import models
 from django.utils import timezone
 
@@ -69,11 +73,11 @@ class Notification(BaseModel):
 
     trigger_name = models.CharField(db_index=True, max_length=50)
 
-    target_user = models.ForeignKey(USER_MODEL, related_name='notifications')
+    target_user = models.ForeignKey(USER_MODEL, related_name='notifications', on_delete=models.CASCADE)
     trigger_user = models.ForeignKey(USER_MODEL, related_name='notifications_sent',
-                                     null=True, default=None)
+                                     null=True, default=None, on_delete=models.CASCADE)
 
-    content_type = models.ForeignKey(ContentType, null=True, blank=True)
+    content_type = models.ForeignKey(ContentType, null=True, blank=True, on_delete=models.CASCADE)
     content_id = models.PositiveIntegerField(null=True, blank=True)
     content = GenericForeignKey('content_type', 'content_id')
     data_pickled = models.TextField(blank=True, editable=False)
@@ -142,7 +146,7 @@ class Notification(BaseModel):
         try:
             self.data_pickled = b64encode(serializer.dumps(self.data)).decode()
         except:
-            self.data_pickled = b64encode(serializer('{}')).decode()
+            self.data_pickled = b64encode(serializer.dumps('{}')).decode()
             self.status = self.Status.BROKEN
         super(Notification, self).save(*args, **kwargs)
 

--- a/transmissions/serializer.py
+++ b/transmissions/serializer.py
@@ -1,0 +1,47 @@
+import pickle
+from importlib import import_module
+from django.core.exceptions import ImproperlyConfigured
+from django.conf import settings
+
+class DefaultSerializer(object):
+    def dumps(self, value):
+        return pickle.dumps(value)
+
+    def loads(self, value):
+        return pickle.loads(value)
+
+
+def load_class(path):
+    """
+    Loads class from path.
+    """
+
+    mod_name, klass_name = path.rsplit('.', 1)
+
+    try:
+        mod = import_module(mod_name)
+    except AttributeError as e:
+        raise ImproperlyConfigured('Error importing {0}: "{1}"'.format(mod_name, e))
+
+    try:
+        klass = getattr(mod, klass_name)
+    except AttributeError:
+        raise ImproperlyConfigured('Module "{0}" does not define a "{1}" class'.format(mod_name, klass_name))
+
+    if not hasattr(klass, "loads"):
+        raise ImproperlyConfigured('Class "{0}" does not define "loads" method'.format(klass_name))
+
+    if not hasattr(klass, "dumps"):
+        raise ImproperlyConfigured('Class "{0}" does not define "dumps" method'.format(klass_name))
+
+    return klass
+
+
+def load_serializer(settings):
+
+    if hasattr(settings, 'TRANSMISSIONS_SERIALIZER'):
+        return load_class(settings.UMEBOSHI_SERIALIZER)()
+    else:
+        return DefaultSerializer()
+
+serializer = load_serializer(settings)

--- a/transmissions/serializer.py
+++ b/transmissions/serializer.py
@@ -40,7 +40,7 @@ def load_class(path):
 def load_serializer(settings):
 
     if hasattr(settings, 'TRANSMISSIONS_SERIALIZER'):
-        return load_class(settings.UMEBOSHI_SERIALIZER)()
+        return load_class(settings.TRANSMISSIONS_SERIALIZER)()
     else:
         return DefaultSerializer()
 


### PR DESCRIPTION
## Change Summary
- Make Pickle serializer customizable so that user can overwrite `dumps` and `loads` behavior to support different data formate. It will be very useful when dealing with Py2 Py3 [compatibility issue](https://rebeccabilbro.github.io/convert-py2-pickles-to-py3/).

## Highlight of Code Change
- Add `DefaultSerializer` with default pickling behavior
- Read `TRANSMISSION_SERIALIZER` from Django config setting, and then use the user provided serializer if class exists.

## Code Sample
Create custom serializer class. Serializer must contains `dumps` and `loads` methods
```
# project/lib/django/serializer.py

import pickle

class CustomSerializer(object):
    def dumps(self, value):
        return pickle.dumps(value, 2)

    def loads(self, value):
        return pickle.loads(value, fix_imports=True, encoding="latin1")
```

Set `TRANSMISSION_SERIALIZER` with serializer path
```
# project/config/common/settings.py

TRANSMISSION_SERIALIZER = "lib.django.serializer.CustomSerializer"
```
